### PR TITLE
Updates for 4.0.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ apply plugin: 'maven'
 
 defaultTasks 'clean', 'distZip', 'distTar'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.11
+targetCompatibility = 1.11
 
 group = 'net.unicon'
 version = project.version
@@ -32,11 +32,12 @@ dependencies {
     provided "javax.servlet:javax.servlet-api:$project.servletVersion"
     provided "net.shibboleth.idp:idp-authn-api:$project.shibIdpVersion"
     provided "net.shibboleth.idp:idp-saml-api:$project.shibIdpVersion"
-    provided "commons-lang:commons-lang:$project.commonLangVersion"
+    provided "org.apache.commons:commons-lang3:$project.commonLangVersion"
 
     testCompile "junit:junit:$project.junitVersion"
-    testCompile "org.mockito:mockito-all:$project.mockitoVersion"
-    testCompile "org.powermock:powermock-mockito-release-full:$project.powermockVersion"
+    testCompile "org.mockito:mockito-core:$project.mockitoVersion"
+    testCompile "org.powermock:powermock-api-mockito2:$project.powermockVersion"
+    testCompile "org.powermock:powermock-module-junit4:$project.powermockVersion"
 }
 
 distributions {
@@ -133,9 +134,4 @@ task down(type: Exec) {
 
 if (new File('./build/docker/').exists()) {
     clean.dependsOn down
-}
-
-
-task wrapper(type: Wrapper) {
-    gradleVersion = project.gradleVersion
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
-gradleVersion=4.5
+gradleVersion=5.6.4
 
 version=4.0.0
 
 casClientVersion=3.6.0
-commonLangVersion=2.5
-junitVersion=4.12
-mockitoVersion=1.9.5
-powermockVersion=1.6.1
-servletVersion=3.0.1
+commonLangVersion=3.11
+junitVersion=4.13.1
+mockitoVersion=3.6.28
+powermockVersion=2.0.9
+servletVersion=4.0.1
 shibIdpVersion=4.0.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip

--- a/src/main/java/net/unicon/idp/externalauth/AuthenticatedNameTranslator.java
+++ b/src/main/java/net/unicon/idp/externalauth/AuthenticatedNameTranslator.java
@@ -1,12 +1,13 @@
 package net.unicon.idp.externalauth;
 
 import net.shibboleth.idp.attribute.IdPAttribute;
+import net.shibboleth.idp.attribute.IdPAttributeValue;
 import net.shibboleth.idp.attribute.StringAttributeValue;
 import net.shibboleth.idp.authn.ExternalAuthentication;
 import net.shibboleth.idp.authn.principal.IdPAttributePrincipal;
 import net.shibboleth.idp.authn.principal.UsernamePrincipal;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.jasig.cas.client.authentication.AttributePrincipal;
 import org.jasig.cas.client.validation.Assertion;
 import org.slf4j.Logger;
@@ -81,7 +82,7 @@ public class AuthenticatedNameTranslator implements CasToShibTranslator {
         for (final Map.Entry<String, Object> entry : casAttributes.entrySet()) {
             final IdPAttribute attr = new IdPAttribute(entry.getKey());
 
-            final List<StringAttributeValue> attributeValues = new ArrayList<>();
+            final List<IdPAttributeValue> attributeValues = new ArrayList<>();
             if (entry.getValue() instanceof Collection) {
                 for (final Object value : (Collection) entry.getValue()) {
                     attributeValues.add(new StringAttributeValue(value.toString()));

--- a/src/main/java/net/unicon/idp/externalauth/CasDuoSecurityRefedsAuthnMethodTranslator.java
+++ b/src/main/java/net/unicon/idp/externalauth/CasDuoSecurityRefedsAuthnMethodTranslator.java
@@ -104,16 +104,13 @@ public class CasDuoSecurityRefedsAuthnMethodTranslator implements CasToShibTrans
                     return new PrincipalEvalPredicate() {
 
                         @Override
-                        public Principal getMatchingPrincipal() {
-                            return principal;
+                        public boolean test(PrincipalSupportingComponent principalSupportingComponent) {
+                            return false;
                         }
 
                         @Override
-                        public boolean apply(@Nullable final PrincipalSupportingComponent input) {
-                            final Set supported = input != null
-                                ? input.getSupportedPrincipals(principal.getClass())
-                                : new HashSet();
-                            return supported.stream().anyMatch(p -> principal.equals(p));
+                        public Principal getMatchingPrincipal() {
+                            return principal;
                         }
                     };
                 }

--- a/src/main/java/net/unicon/idp/externalauth/ShibcasAuthServlet.java
+++ b/src/main/java/net/unicon/idp/externalauth/ShibcasAuthServlet.java
@@ -5,7 +5,7 @@ import net.shibboleth.idp.authn.ExternalAuthentication;
 import net.shibboleth.idp.authn.ExternalAuthenticationException;
 import net.unicon.idp.authn.provider.extra.EntityIdParameterBuilder;
 import net.unicon.idp.authn.provider.extra.IParameterBuilder;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.cas.client.util.CommonUtils;
 import org.jasig.cas.client.validation.AbstractCasProtocolUrlBasedTicketValidator;
 import org.jasig.cas.client.validation.Assertion;
@@ -217,8 +217,8 @@ public class ShibcasAuthServlet extends HttpServlet {
         for (final String parameterBuilder : StringUtils.split(builders, ";")) {
             try {
                 logger.debug("Loading parameter builder class {}", parameterBuilder);
-                final Class clazz = Class.forName(parameterBuilder);
-                final IParameterBuilder builder = IParameterBuilder.class.cast(clazz.newInstance());
+                final Class<?> clazz = Class.forName(parameterBuilder);
+                final IParameterBuilder builder = IParameterBuilder.class.cast(clazz.getDeclaredConstructor().newInstance());
                 if (builder instanceof ApplicationContextAware) {
                     ((ApplicationContextAware) builder).setApplicationContext(applicationContext);
                 }
@@ -242,7 +242,7 @@ public class ShibcasAuthServlet extends HttpServlet {
             try {
                 logger.debug("Loading translator class {}", classname);
                 final Class<?> c = Class.forName(classname);
-                final CasToShibTranslator e = (CasToShibTranslator) c.newInstance();
+                final CasToShibTranslator e = (CasToShibTranslator) c.getDeclaredConstructor().newInstance();
                 if (e instanceof EnvironmentAware) {
                     ((EnvironmentAware) e).setEnvironment(environment);
                 }

--- a/src/test/java/net/unicon/idp/externalauth/ShibcasAuthServletTest.java
+++ b/src/test/java/net/unicon/idp/externalauth/ShibcasAuthServletTest.java
@@ -2,7 +2,7 @@ package net.unicon.idp.externalauth;
 
 import net.shibboleth.idp.authn.ExternalAuthentication;
 import net.shibboleth.idp.authn.ExternalAuthenticationException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.cas.client.authentication.AttributePrincipal;
 import org.jasig.cas.client.validation.Assertion;
 import org.jasig.cas.client.validation.Cas20ServiceTicketValidator;
@@ -14,22 +14,27 @@ import org.mockito.BDDMockito;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.api.support.membermodification.MemberModifier;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 import org.springframework.web.context.WebApplicationContext;
-
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.any;
+
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.*.*", "com.sun.*","org.w3c.*", "org.xml.*","javax.management.*", "javax.net.ssl.*"})
 @PrepareForTest({ExternalAuthentication.class, Cas20ServiceTicketValidator.class})
 public class ShibcasAuthServletTest {
     private String CONVERSATION = "conversation=e1s1";


### PR DESCRIPTION
Fixes error when using the translator for REFEDS MFA.
Updates dependencies to latest library versions.
Modifies code only to support newer Java and Opensaml changes. No new features.
Supports Java 11.