### PR TITLE
entityId embeded : check that entityIdLocation has not been modified by user

### DIFF
--- a/src/test/java/net/unicon/idp/externalauth/ShibcasAuthServletTest.java
+++ b/src/test/java/net/unicon/idp/externalauth/ShibcasAuthServletTest.java
@@ -235,7 +235,7 @@ public class ShibcasAuthServletTest {
     @Test
     public void testConstructServiceUrlEmbed() throws Exception {
         //Mock some objects.
-        final HttpServletRequest request = createDoGetHttpServletRequest(CONVERSATION_TICKET + "&entityId=http://test.edu/sp", TICKET, "false");
+        final HttpServletRequest request = createDoGetHttpServletRequest(CONVERSATION_TICKET + "&entityId=http://test.edu/sp", TICKET, "false", "http://test.edu/sp");
         final HttpServletResponse response = createMockHttpServletResponse();
 
         //Prep our object
@@ -350,6 +350,18 @@ public class ShibcasAuthServletTest {
 
         return request;
     }
+    
+
+    private HttpServletRequest createDoGetHttpServletRequest(final String queryString, final String ticket, final String gatewayAttempted, final String entityId) {
+    	final HttpServletRequest request = createMockHttpServletRequest();
+
+        BDDMockito.given(request.getQueryString()).willReturn(queryString);
+        BDDMockito.given(request.getParameter("ticket")).willReturn(ticket);
+        BDDMockito.given(request.getParameter("gatewayAttempted")).willReturn(gatewayAttempted);
+        BDDMockito.given(request.getParameter("entityId")).willReturn(entityId);
+
+        return request;
+	}
 
     private Assertion createMockAssertion() {
         final Assertion assertion = Mockito.mock(Assertion.class);


### PR DESCRIPTION
Cf documentation we can use shibcas.entityIdLocation=embed to distinguish  2 different serviceIds on CAS configuration :

> By setting shibcas.entityIdLocation=embed, shib-cas-authn will embed the entityId in the service string so that CAS Server can use the entityId when evaluating a service registry entry match. Using serviceIds of something like: https://shibserver.example.edu/idp/Authn/ExtCas\?conversation=[a-z0-9]*&entityId=http://testsp.school.edu/sp or https://shibserver.example.edu/idp/Authn/ExtCas\?conversation=[a-z0-9]*&entityId=http://test.unicon.net/sp will match as two different entries in the service registry which will allow as CAS admin to enable MFA or use access strategies on an SP by SP basis.

Problem is that when the user comes to CAS server, he can simply modify the entityId http parameter and no check is done.

So if in CAS we setup MFA for  
`https://shibserver.example.edu/idp/Authn/ExtCas\?conversation=[a-z0-9]*&entityId=http://testsp.school.edu/sp` 
but not for 
`https://shibserver.example.edu/idp/Authn/ExtCas\?conversation=[a-z0-9]*&entityId=http://test.unicon.net/sp` 

If an user want to bypass MFA when it try to authenticate on `http://testsp.school.edu/sp`, he can replace `testsp.school.edu` with `test.unicon.net/sp` on the cas auth url (the user simply modify the url on address bar and replay the get)

That is to say, for example, replace

 `https://cas.school.edu/login?service=https%3A%2F%2Fidp.school.edu%2Fidp%2FAuthn%2FExternal%3Fconversation%3De2s1%26entityId%3Dhttps%3A%2F%2Ftestsp.school.edu/sp` 
with  
`https://cas.school.edu/login?service=https%3A%2F%2Fidp.school.edu%2Fidp%2FAuthn%2FExternal%3Fconversation%3De2s1%26entityId%3Dhttps%3A%2F%2Ftest.unicon.net/sp` 

With this patch/pr, shib-cas-authn checks that entityIdLocation has not been modified by user and the user can't no more bypass the MFA by modifying the entityId http parameter part.
