### PR TITLE
add option "shibcas.doNotCache"

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ shibcas.serverName = https://shibserver.example.edu
 # Specify if the Relying Party/Service Provider entityId should be appended as a separate entityId query string parameter
 # or embedded in the "service" querystring parameter - `append` (default) or `embed`
 # shibcas.entityIdLocation = append
+
+# If you decide to embed entityId in querystring, CAS can decide MFA based on entityId.
+# In that case you do not want to cache the result
+# (otherwise the first succesful CAS login will be kept)
+# (alternative is to use "idp.session.enabled = false" but you loose SLO)
+#shibcas.doNotCache = true
+
 ...
 ```
 

--- a/src/main/java/net/unicon/idp/externalauth/ShibcasAuthServlet.java
+++ b/src/main/java/net/unicon/idp/externalauth/ShibcasAuthServlet.java
@@ -53,6 +53,7 @@ public class ShibcasAuthServlet extends HttpServlet {
     private String casServerPrefix;
     private String ticketValidatorName;
     private String entityIdLocation;
+    private Boolean doNotCache;
 
     private AbstractCasProtocolUrlBasedTicketValidator ticketValidator;
 
@@ -107,6 +108,10 @@ public class ShibcasAuthServlet extends HttpServlet {
             for (final CasToShibTranslator casToShibTranslator : translators) {
                 casToShibTranslator.doTranslation(request, response, assertion, authenticationKey);
             }
+            if (doNotCache) {
+                request.setAttribute(ExternalAuthentication.DONOTCACHE_KEY, true);
+            }
+
         } catch (final Exception e) {
             logger.error("Ticket validation failed, returning InvalidTicket", e);
             request.setAttribute(ExternalAuthentication.AUTHENTICATION_ERROR_KEY, "InvalidTicket");
@@ -209,6 +214,9 @@ public class ShibcasAuthServlet extends HttpServlet {
 
         entityIdLocation = environment.getProperty("shibcas.entityIdLocation", "append");
         logger.debug("shibcas.entityIdLocation: {}", entityIdLocation);
+
+        doNotCache = Boolean.parseBoolean(environment.getProperty("shibcas.doNotCache"));
+        logger.debug(properties_prefix + ".doNotCache: {}", doNotCache);
     }
 
     private void buildParameterBuilders(final ApplicationContext applicationContext) {


### PR DESCRIPTION
If you decide to embed entityId in querystring, CAS can decide MFA based on entityId.
In that case you do not want to cache the result
(otherwise the first succesful CAS login will be kept)

(alternative is to use "idp.session.enabled = false" but you loose SLO)
