### PR TITLE
fix typo in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Example snippet `web.xml`:
 ...
 idp.authn.flows = External
 
-dp.authn.External.externalAuthnPath = contextRelative:Authn/External
+idp.authn.External.externalAuthnPath = contextRelative:Authn/External
 
 shibcas.casServerUrlPrefix = https://cassserver.example.edu/cas
 shibcas.casServerLoginUrl = ${shibcas.casServerUrlPrefix}/login


### PR DESCRIPTION
Typo in README.md 
the correct path is "idp.authn.External.externalAuthnPath"